### PR TITLE
Use axios instead of fetch

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "include": ["src"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@js4cytoscape/ndex-client": "^0.3.2",
         "@tailwindcss/forms": "^0.5.9",
         "@tanstack/react-query": "^5.60.5",
+        "axios": "^1.7.9",
         "clsx": "^2.1.0",
         "cytoscape": "^3.30.0",
         "cytoscape-fcose": "^2.2.0",
@@ -987,6 +988,15 @@
       },
       "engines": {
         "node": ">=12.16.1"
+      }
+    },
+    "node_modules/@js4cytoscape/ndex-client/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2139,6 +2149,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -2192,11 +2208,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2497,6 +2516,18 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2715,6 +2746,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/didyoumean": {
@@ -3438,6 +3478,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4899,6 +4953,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5637,6 +5712,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "prettier": "^3.4.2",
         "prettier-eslint": "^16.3.0",
         "tailwindcss": "^3.4.15",
+        "typescript": "^5.7.2",
         "vite": "^5.4.11",
         "vite-plugin-svgr": "^4.3.0"
       }
@@ -6715,6 +6716,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prettier": "^3.4.2",
     "prettier-eslint": "^16.3.0",
     "tailwindcss": "^3.4.15",
+    "typescript": "^5.7.2",
     "vite": "^5.4.11",
     "vite-plugin-svgr": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@js4cytoscape/ndex-client": "^0.3.2",
     "@tailwindcss/forms": "^0.5.9",
     "@tanstack/react-query": "^5.60.5",
+    "axios": "^1.7.9",
     "clsx": "^2.1.0",
     "cytoscape": "^3.30.0",
     "cytoscape-fcose": "^2.2.0",

--- a/src/components/utilities/geneManiaUtils.jsx
+++ b/src/components/utilities/geneManiaUtils.jsx
@@ -1,27 +1,26 @@
+import axios from "axios";
 import Cytoscape from "cytoscape";
 
 export async function fetchGeneManiaNetwork(genes, organismId = 4) {
     try {
+        console.log("called")
       const baseUrl = "https://genemania.org/json/search_results";
-      const response = await fetch(`${baseUrl}`, {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+      const response = await axios.post(baseUrl, {
           organism: organismId,
           genes: genes,
           weighting: "AUTOMATIC_SELECT",
           geneThreshold: genes.length === 1 ? 0 : 20,
           attrThreshold: 0,
-        }),
+        }, {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
       });
-      if (!response.ok) {
-        throw new Error(`HTTP error! Status: ${response.status}`);
+      if (response.data.error) {
+        throw new Error(response.data.error);
       }
-      const json = await response.json();
-      return json;
+      return response.data;
     } catch (error) {
       console.error("Error:", error.message);
       return { error: { message: error.message } };

--- a/src/components/utilities/geneManiaUtils.jsx
+++ b/src/components/utilities/geneManiaUtils.jsx
@@ -1,10 +1,9 @@
-import axios from "axios";
 import Cytoscape from "cytoscape";
+import { Network } from "../../network/Network";
 
 export async function fetchGeneManiaNetwork(genes, organismId = 4) {
     try {
-      const baseUrl = "https://genemania.org/json/search_results";
-      const response = await axios.post(baseUrl, {
+      const response = await Network.post("/search_results", {
           organism: organismId,
           genes: genes,
           weighting: "AUTOMATIC_SELECT",

--- a/src/components/utilities/geneManiaUtils.jsx
+++ b/src/components/utilities/geneManiaUtils.jsx
@@ -3,7 +3,6 @@ import Cytoscape from "cytoscape";
 
 export async function fetchGeneManiaNetwork(genes, organismId = 4) {
     try {
-        console.log("called")
       const baseUrl = "https://genemania.org/json/search_results";
       const response = await axios.post(baseUrl, {
           organism: organismId,

--- a/src/components/utilities/geneManiaUtils.jsx
+++ b/src/components/utilities/geneManiaUtils.jsx
@@ -10,12 +10,7 @@ export async function fetchGeneManiaNetwork(genes, organismId = 4) {
           weighting: "AUTOMATIC_SELECT",
           geneThreshold: genes.length === 1 ? 0 : 20,
           attrThreshold: 0,
-        }, {
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-      });
+        });
       if (response.data.error) {
         throw new Error(response.data.error);
       }

--- a/src/network/Network.ts
+++ b/src/network/Network.ts
@@ -1,0 +1,5 @@
+import { NetworkRepository } from "./NetworkRepository";
+import { NetworkRepositoryAxiosImpl } from "./NetworkRepositoryAxiosImpl";
+
+const baseUrl = "https://genemania.org/json/";
+export const Network: NetworkRepository = new NetworkRepositoryAxiosImpl(baseUrl);

--- a/src/network/NetworkRepository.ts
+++ b/src/network/NetworkRepository.ts
@@ -1,0 +1,54 @@
+import { AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+export type NetworkRequestConfig<Data = any> = AxiosRequestConfig<Data>;
+type InternalNetworkRequestConfig<Data = any> = InternalAxiosRequestConfig<Data>;
+export type NetworkResponse<Data = any> = AxiosResponse<Data>;
+
+/**
+ * @returns eject function
+ */
+type NetworkInterceptorFunction<Config> = (
+    ...params: Parameters<AxiosInterceptorManager<Config>['use']>
+) => VoidFunction;
+
+export interface NetworkRepository {
+    // API methods
+    get<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    post<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    /**
+     * Similar to `post`, but content-type header is set to 'multipart/form-data'.
+     * Use `postForm` for attachment uploads
+     */
+    postForm<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    put<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    patch<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    delete<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    getFile<RequestData = any>(
+        url: string,
+        config?: Omit<NetworkRequestConfig<RequestData>, 'responseType'>,
+    ): Promise<NetworkResponse<ArrayBuffer>>;
+
+    getBaseURL(): string;
+}

--- a/src/network/NetworkRepositoryAxiosImpl.ts
+++ b/src/network/NetworkRepositoryAxiosImpl.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosInstance } from 'axios';
+import { NetworkRepository } from './NetworkRepository';
+
+export class NetworkRepositoryAxiosImpl implements NetworkRepository {
+    readonly #baseURL: string;
+
+    readonly #instance: AxiosInstance;
+
+    constructor(baseURL: string) {
+        this.#baseURL = baseURL;
+        this.#instance = axios.create({
+            baseURL,
+            timeout: 15000
+        });
+    }
+
+    public get: NetworkRepository['get'] = (url, config) => this.#instance.get(url, config);
+
+    public post: NetworkRepository['post'] = (url, data, config) => this.#instance.post(url, data, config);
+
+    public postForm: NetworkRepository['postForm'] = (url, data, config) => this.#instance.postForm(url, data, config);
+
+    public put: NetworkRepository['put'] = (url, data, config) => this.#instance.put(url, data, config);
+
+    public patch: NetworkRepository['patch'] = (url, data, config) => this.#instance.patch(url, data, config);
+
+    public delete: NetworkRepository['delete'] = (url, config) => this.#instance.delete(url, config);
+
+    public getFile: NetworkRepository['getFile'] = async (url, config) => {
+        const response = await this.get<ArrayBuffer>(url, {
+            responseType: 'arraybuffer',
+            ...config,
+        });
+        return response;
+    };
+
+    public getBaseURL(): string {
+        return this.#baseURL;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "system",
+    "noImplicitAny": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "outFile": "../../built/local/tsc.js",
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,20 @@
 {
   "compilerOptions": {
-    "module": "system",
-    "noImplicitAny": true,
-    "removeComments": true,
-    "preserveConstEnums": true,
-    "outFile": "../../built/local/tsc.js",
-    "sourceMap": true,
-    "skipLibCheck": true
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": [],
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
   },
   "include": ["src/**/*"],
 }


### PR DESCRIPTION
# Addressed Issue
`fetch` currently had a lot of limitation in its API for examples, developers need to manually serialize and deserialized the request JSON body every single time when fetch is called. It also has limtations where developers are unable to declare and use a single configuration throughout all instances of `fetch`. It also does not come with useful features like having request and response interceptors which would be helpful in the future especially when applying global logic to all network call. A more advanced and flexible data fetching library is needed to provide us with a more powerful and easier way to do data fetching.

# What you have reengineered
All instances of `fetch` is then refactored to use `axios` to ease maintainability. All of the payload of fetch is refactored to follow the standards of `axios`.

# Reengineering strategy or apporach used
The `axios` package is installed to allow importing and use the more enhanced data fetching library which is axios in this case. All instances of `fetch` is then refactored to use axios to ease maintainability.

# Impact of Changes
This changes remove redundants JSON serializing and deserializing everytime when making a network request. Thereby reducing the amount of code in the system. It also unlocks the door for useful features like sharing configuration via one instance of `axios` and allows us to use request and response interceptors.