### PR TITLE
Abstract Network Interface

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "include": ["src"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "prettier": "^3.4.2",
         "prettier-eslint": "^16.3.0",
         "tailwindcss": "^3.4.15",
+        "typescript": "^5.7.2",
         "vite": "^5.4.11",
         "vite-plugin-svgr": "^4.3.0"
       }
@@ -6715,6 +6716,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prettier": "^3.4.2",
     "prettier-eslint": "^16.3.0",
     "tailwindcss": "^3.4.15",
+    "typescript": "^5.7.2",
     "vite": "^5.4.11",
     "vite-plugin-svgr": "^4.3.0"
   },

--- a/src/components/utilities/geneManiaUtils.jsx
+++ b/src/components/utilities/geneManiaUtils.jsx
@@ -1,10 +1,9 @@
-import axios from "axios";
 import Cytoscape from "cytoscape";
+import { Network } from "../../network/Network";
 
 export async function fetchGeneManiaNetwork(genes, organismId = 4) {
     try {
-      const baseUrl = "https://genemania.org/json/search_results";
-      const response = await axios.post(baseUrl, {
+      const response = await Network.post("/search_results", {
           organism: organismId,
           genes: genes,
           weighting: "AUTOMATIC_SELECT",

--- a/src/network/Network.ts
+++ b/src/network/Network.ts
@@ -1,0 +1,5 @@
+import { NetworkRepository } from "./NetworkRepository";
+import { NetworkRepositoryAxiosImpl } from "./NetworkRepositoryAxiosImpl";
+
+const baseUrl = "https://genemania.org/json/";
+export const Network: NetworkRepository = new NetworkRepositoryAxiosImpl(baseUrl);

--- a/src/network/NetworkRepository.ts
+++ b/src/network/NetworkRepository.ts
@@ -1,0 +1,54 @@
+import { AxiosInterceptorManager, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+export type NetworkRequestConfig<Data = any> = AxiosRequestConfig<Data>;
+type InternalNetworkRequestConfig<Data = any> = InternalAxiosRequestConfig<Data>;
+export type NetworkResponse<Data = any> = AxiosResponse<Data>;
+
+/**
+ * @returns eject function
+ */
+type NetworkInterceptorFunction<Config> = (
+    ...params: Parameters<AxiosInterceptorManager<Config>['use']>
+) => VoidFunction;
+
+export interface NetworkRepository {
+    // API methods
+    get<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    post<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    /**
+     * Similar to `post`, but content-type header is set to 'multipart/form-data'.
+     * Use `postForm` for attachment uploads
+     */
+    postForm<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    put<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    patch<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        data?: RequestData,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    delete<ResponseData = any, Response = NetworkResponse<ResponseData>, RequestData = any>(
+        url: string,
+        config?: NetworkRequestConfig<RequestData>,
+    ): Promise<Response>;
+    getFile<RequestData = any>(
+        url: string,
+        config?: Omit<NetworkRequestConfig<RequestData>, 'responseType'>,
+    ): Promise<NetworkResponse<ArrayBuffer>>;
+
+    getBaseURL(): string;
+}

--- a/src/network/NetworkRepositoryAxiosImpl.ts
+++ b/src/network/NetworkRepositoryAxiosImpl.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosInstance } from 'axios';
+import { NetworkRepository } from './NetworkRepository';
+
+export class NetworkRepositoryAxiosImpl implements NetworkRepository {
+    readonly #baseURL: string;
+
+    readonly #instance: AxiosInstance;
+
+    constructor(baseURL: string) {
+        this.#baseURL = baseURL;
+        this.#instance = axios.create({
+            baseURL,
+            timeout: 15000
+        });
+    }
+
+    public get: NetworkRepository['get'] = (url, config) => this.#instance.get(url, config);
+
+    public post: NetworkRepository['post'] = (url, data, config) => this.#instance.post(url, data, config);
+
+    public postForm: NetworkRepository['postForm'] = (url, data, config) => this.#instance.postForm(url, data, config);
+
+    public put: NetworkRepository['put'] = (url, data, config) => this.#instance.put(url, data, config);
+
+    public patch: NetworkRepository['patch'] = (url, data, config) => this.#instance.patch(url, data, config);
+
+    public delete: NetworkRepository['delete'] = (url, config) => this.#instance.delete(url, config);
+
+    public getFile: NetworkRepository['getFile'] = async (url, config) => {
+        const response = await this.get<ArrayBuffer>(url, {
+            responseType: 'arraybuffer',
+            ...config,
+        });
+        return response;
+    };
+
+    public getBaseURL(): string {
+        return this.#baseURL;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "system",
+    "noImplicitAny": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "outFile": "../../built/local/tsc.js",
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,20 @@
 {
   "compilerOptions": {
-    "module": "system",
-    "noImplicitAny": true,
-    "removeComments": true,
-    "preserveConstEnums": true,
-    "outFile": "../../built/local/tsc.js",
-    "sourceMap": true,
-    "skipLibCheck": true
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": [],
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
   },
   "include": ["src/**/*"],
 }


### PR DESCRIPTION
# Addressed Issue
Using `axios` directly throughout the application makes the usage very inconsistent. Developers would have a hard time centralising all of the logic into one place thereby increasing maintenance overhead if we would need to apply configurations globally into all of the data fetching call throughout the application. Not having an abstraction layer also would complicated future migrations to other data fetching library.

# What you have reengineered
Refactored the axios data fetching request throughout the app by abstracting a layer between axios and our application.

# Reengineering strategy or apporach used
An interface called `NetworkRepository` is declared to define the network fetching logic that our application would be using and third party package would need to abide to our application interface. An implementation of the data fetching library, in this case `axios` is created based on the interface. The implementation is then consumed and finally exported throughout a common `Network` function which is exported out for consumer to use.

# Impact of Changes
- Improved code maintainability by centralizing network request logic.
- Enhanced consistency and reliability of network operations.
- Simplified future updates and modifications to the network communication layer.